### PR TITLE
Silence ob_flush() and flush() to avoid notice

### DIFF
--- a/new-post-format-unmigrator.php
+++ b/new-post-format-unmigrator.php
@@ -387,8 +387,8 @@ class New_Post_Format_Unmigrator_UI {
 	 * Flushes the current buffer to the page.
 	 */
 	public function flush() {
-		ob_flush();
-		flush();
+		@ob_flush();
+		@flush();
 	}
 }
 


### PR DESCRIPTION
Saw a notice when running the migration:

```
PHP Notice: ob_flush(): failed to flush buffer. No buffer to flush. in wp-content/mu-plugins/new-post-format-unmigrator.php on line 390
```

Perhaps both calls should be silenced to avoid the notice.
